### PR TITLE
include web in build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,12 @@ RUN PATH_CONFIG=./config.properties \
 	PATH_MAIL_TEMPLATES=./gmcserver-email/ \
 	make -e
 
+FROM node:16.2.0-buster AS builder-web
+WORKDIR /build
+COPY gmcserver-web/ .
+RUN npm install -g pnpm && \
+	make
+
 FROM node:16.2.0-buster AS builder-email
 WORKDIR /build
 COPY gmcserver-email/ .
@@ -25,6 +31,7 @@ WORKDIR /build
 COPY --from=builder /build/target/gmcserver*jar-with-dependencies.jar ./gmcserver.jar
 COPY --from=builder /build/mail.json /build/vertx.json ./
 COPY --from=builder /build/config.example.properties ./config.properties
+COPY --from=builder-web /build/build/ ./gmcserver-web/
 COPY --from=builder-email /build/out/ ./gmcserver-email/
 EXPOSE 8080
 


### PR DESCRIPTION
unfortunately, settings the config webroot to be /build/gmcserver-web fails with:

```
[35m2021-10-16 04:24:03[m [1m[1;31mERROR[m[m : [1m[vert.x-eventloop-thread-0][m [36m[me.vi.gm.ha.WebHandler][m - Failed to read file /build/gmcserver-web

io.vertx.core.file.FileSystemException: java.io.IOException: Is a directory
at io.vertx.core.file.impl.FileSystemImpl$16.perform(FileSystemImpl.java:1045) ~[gmcserver.jar:?]
at io.vertx.core.file.impl.FileSystemImpl$16.perform(FileSystemImpl.java:1037) ~[gmcserver.jar:?]
at io.vertx.core.file.impl.FileSystemImpl$BlockingAction.handle(FileSystemImpl.java:1149) ~[gmcserver.jar:?]
at io.vertx.core.file.impl.FileSystemImpl$BlockingAction.handle(FileSystemImpl.java:1131) ~[gmcserver.jar:?]
at io.vertx.core.impl.ContextImpl.lambda$null$0(ContextImpl.java:159) ~[gmcserver.jar:?]
at io.vertx.core.impl.AbstractContext.dispatch(AbstractContext.java:100) ~[gmcserver.jar:?]
at io.vertx.core.impl.ContextImpl.lambda$executeBlocking$1(ContextImpl.java:157) ~[gmcserver.jar:?]
at io.vertx.core.impl.TaskQueue.run(TaskQueue.java:76) ~[gmcserver.jar:?]
at java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source) ~[?:?]
at java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source) ~[?:?]
at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [gmcserver.jar:?]
at java.lang.Thread.run(Unknown Source) [?:?]
Caused by: java.io.IOException: Is a directory
at sun.nio.ch.FileDispatcherImpl.read0(Native Method) ~[?:?]
at sun.nio.ch.FileDispatcherImpl.read(Unknown Source) ~[?:?]
at sun.nio.ch.IOUtil.readIntoNativeBuffer(Unknown Source) ~[?:?]
at sun.nio.ch.IOUtil.read(Unknown Source) ~[?:?]
at sun.nio.ch.FileChannelImpl.read(Unknown Source) ~[?:?]
at sun.nio.ch.ChannelInputStream.read(Unknown Source) ~[?:?]
at sun.nio.ch.ChannelInputStream.read(Unknown Source) ~[?:?]
at sun.nio.ch.ChannelInputStream.read(Unknown Source) ~[?:?]
at java.nio.file.Files.read(Unknown Source) ~[?:?]
at java.nio.file.Files.readAllBytes(Unknown Source) ~[?:?]
at io.vertx.core.file.impl.FileSystemImpl$16.perform(FileSystemImpl.java:1041) ~[gmcserver.jar:?]
... 11 more
```